### PR TITLE
PR#2 04_02

### DIFF
--- a/backend/middleware/authMiddleware.ts
+++ b/backend/middleware/authMiddleware.ts
@@ -9,15 +9,16 @@ export interface CustomRequest extends Request {
   authUser?: tokenBody
 }
 
-export default async function isAuthenticated(
+export default function isAuthenticated(
   req: CustomRequest,
   res: Response,
   next: NextFunction
-): Promise<any> {
+):void {
   const token = req.headers['authorization']?.split(' ')[1]
 
   if (!token) {
-    return res.status(401).json({ message: 'Unauthorized' })
+    res.status(401).json({ message: 'Unauthorized' })
+    return
   }
 
   try {
@@ -31,6 +32,7 @@ export default async function isAuthenticated(
     req.authUser = decodedToken
     next()
   } catch (error) {
-    return res.status(401).json({ message: 'Invalid or expired token.' })
+     res.status(401).json({ message: 'Invalid or expired token.' })
+     return
   }
 }


### PR DESCRIPTION
- Changed the return type of the isAuthenticated middleware to void. Earlier, I've assigned that function as an async one, but it's not, so I fixed it by removing the async designation and changing its return type from Promise<any> to void;