### PR TITLE
fix: migration applied manually, not needed on dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,6 @@ RUN npm install
 
 COPY . .
 RUN npx prisma generate
-RUN npx prisma migrate deploy
 RUN npm run build
 
 # Stage 2 - Runner


### PR DESCRIPTION
Since the migrations with the supabase URL were apllied manually, there is no need to run npx prisma migrate deploy on backend dockerfile